### PR TITLE
linear vs BST 속도 비교

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,66 @@
-export const solution = (arr: number[]) => {
-  return arr.length;
+class TreeNode {
+  value: number;
+  left: TreeNode | null;
+  right: TreeNode | null;
+
+  constructor(value: number) {
+    this.value = value;
+    this.left = null;
+    this.right = null;
+  }
+}
+
+export class BinarySearchTree {
+  root: TreeNode | null;
+
+  constructor() {
+    this.root = null;
+  }
+
+
+  insert(value: number): void {
+    this.root = this.insertNode(this.root, value);
+  }
+
+
+  private insertNode(node: TreeNode | null, value: number): TreeNode {
+    if (node === null) {
+      return new TreeNode(value);
+    }
+
+    if (value < node.value) {
+      node.left = this.insertNode(node.left, value);
+    } else if (value > node.value) {
+      node.right = this.insertNode(node.right, value);
+    }
+
+    return node;
+  }
+
+  search(value: number): boolean {
+    return this.searchNode(this.root, value);
+  }
+
+  private searchNode(node: TreeNode | null, value: number): boolean {
+    if (node === null) {
+      return false;
+    }
+
+    if (value === node.value) {
+      return true;
+    }
+
+    if (value < node.value) {
+      return this.searchNode(node.left, value);
+    } else {
+      return this.searchNode(node.right, value);
+    }
+  }
+}
+
+
+// Export the solution function for compatibility with existing tests
+export function solution(input: string): number {
+  // Placeholder implementation for existing tests
+  return input.length;
 }

--- a/src/test/app.test.ts
+++ b/src/test/app.test.ts
@@ -1,12 +1,79 @@
-import { solution } from "../app";
+import { solution, BinarySearchTree } from "../app";
 
-describe("Solution", () => {
-    it(`Test 1`, () => {
-        expect(
-            solution([1, 3, 2])
-        ).toBe(true);
-    });
+// Linear search function
+function linearSearch(arr: number[], target: number): boolean {
+    for (let i = 0; i < arr.length; i++) {
+        if (arr[i] === target) {
+            return true;
+        }
+    }
+    return false;
+}
 
-    it(`Test 2`, () => {
-    });
+// Shuffle array function
+function shuffle(array: number[]): number[] {
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
+
+describe("Performance Tests", () => {
+    const size = 10_000_000; // 100 million elements
+    const searchTarget = Math.floor(Math.random() * size) + 1; // 1부터 size까지 중 랜덤
+
+    it(`Linear Search Performance Test (O(n))`, () => {
+        console.log(`\n=== Linear Search Test ===`);
+        console.log(`Dataset size: ${size.toLocaleString()} elements`);
+        console.log(`Searching for: ${searchTarget.toLocaleString()}`);
+
+        // Generate sequential numbers 1 to size, then shuffle
+        const numbers: number[] = [];
+        for (let i = 1; i <= size; i++) {
+            numbers.push(i);
+        }
+        const shuffledNumbers = shuffle(numbers);
+
+        // Test linear search
+        const start = performance.now();
+        const found = linearSearch(shuffledNumbers, searchTarget);
+        const end = performance.now();
+        const time = end - start;
+
+        console.log(`Time: ${time.toFixed(2)}ms`);
+        console.log(`=========================\n`);
+
+        expect(found).toBe(true); // Should always find it
+    }, 60000); // 1 minute timeout
+
+    it(`BST Search Performance Test (O(log n))`, () => {
+        console.log(`\n=== BST Search Test ===`);
+        console.log(`Dataset size: ${size.toLocaleString()} elements`);
+        console.log(`Searching for: ${searchTarget.toLocaleString()}`);
+
+        // Generate sequential numbers 1 to size, then shuffle and insert into BST
+        const numbers: number[] = [];
+        for (let i = 1; i <= size; i++) {
+            numbers.push(i);
+        }
+        const shuffledNumbers = shuffle(numbers);
+
+        const bst = new BinarySearchTree();
+        for (const num of shuffledNumbers) {
+            bst.insert(num);
+        }
+
+        // Test BST search
+        const start = performance.now();
+        const found = bst.search(searchTarget);
+        const end = performance.now();
+        const time = end - start;
+
+        console.log(`Time: ${time.toFixed(4)}ms`);
+        console.log(`=====================\n`);
+
+        expect(found).toBe(true); // Should always find it
+    }, 60000); // 1 minute timeout
 });


### PR DESCRIPTION
# BST vs Linear 
- BST: 0.0918ms
- Linear: 2.01ms
---
- 셔플 로직을 끄면 BST 재귀 호출 과정에서 스택 오버플로우가 발생한다.
- 약 1억 건 정도의 데이터를 삽입해 보니 BST의 insert 속도가 매우 느렸다.
- 이는 메모리 할당 횟수가 Linear 방식 보다 훨씬 더 많기 때문이다.
- 다만 search 속도는 Linear 방식 대비 압도적으로 빠른 것을 확인했다.


<img width="1476" height="1680" alt="image" src="https://github.com/user-attachments/assets/1f3b14a0-e2c2-4d5a-b06d-676eb3863886" />

<img width="1124" height="260" alt="image" src="https://github.com/user-attachments/assets/6598323f-5ff1-4bb8-a501-27dab2c6d9d0" />

---
<img width="1035" height="486" alt="image" src="https://github.com/user-attachments/assets/6910bdf1-85c5-4dd9-9147-fb4b282d5f9d" />

비문 교정을 잘 해보자..! 커뮤니케이션이 문제다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a new binary search tree utility with fast insert and search operations for efficient in-memory lookups.
  * Maintains existing API behavior; no breaking changes.

* Tests
  * Introduced large-scale performance tests comparing linear and tree-based searches, with timing logs to validate behavior under heavy datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->